### PR TITLE
Port over some hopefully uncontroversial content from the CEH

### DIFF
--- a/open-source-committee/SUMMARY.md
+++ b/open-source-committee/SUMMARY.md
@@ -14,4 +14,6 @@
 
 * [Introduction](policies/introduction.md)
 * [Governance](policies/governance.md)
+* [Documentation](policies/documentation.md)
+* [Legal](policies/legal.md)
 * [Glossary](policies/glossary.md)

--- a/open-source-committee/policies/CODE-OF-CONDUCT.md
+++ b/open-source-committee/policies/CODE-OF-CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[code-of-conduct@iohk.io](mailto:code-of-conduct@iohk.io).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/open-source-committee/policies/CODE-OF-CONDUCT.md
+++ b/open-source-committee/policies/CODE-OF-CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[code-of-conduct@iohk.io](mailto:code-of-conduct@iohk.io).
+[ospo@intersectmbo.org](mailto:ospo@intersectmbo.org).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/open-source-committee/policies/documentation.md
+++ b/open-source-committee/policies/documentation.md
@@ -1,0 +1,23 @@
+# Documentation
+
+## Recommended documents
+
+A project should contain the following documents:
+
+- `README`
+- `CONTRIBUTING`
+- `CODE_OF_CONDUCT`
+- A `CHANGELOG` (if the project includes multiple packages or similar, then one `CHANGELOG` per package may be more appropriate)
+
+The documents should be easily accessible and discoverable, ideally by being put in standard locations.
+
+The content of these documents is largely up to the project contributors, but we include some additional policies below
+In the following, when we say that a document should include information, this can either mean it includes it directly, or that it clearly links to where it can be found.
+
+### README
+
+The project `README` should include any information that is necessary according to the [governance policy](./governance.md).
+
+### CODE OF CONDUCT
+
+Individual projects SHOULD use the [default Code of Conduct in this repository](https://github.com/intersectMBO/documentation/blob/master/open-source-committe/policies/CODE-OF-CONDUCT.md), either by copying it or creating a `CODE_OF_CONDUCT` document that just links to it.

--- a/open-source-committee/policies/governance.md
+++ b/open-source-committee/policies/governance.md
@@ -202,7 +202,7 @@ The Chair is responsible for organizing and running meetings, and the Secretary 
 The Chair and the Secretary are elected by the PMC. The Chair and the Secretary need not be Committers. 
 If there is no Chair or the PMC is failing to appoint a Chair, then Intersect may appoint an interim Chair.
 
-PMC meetings should be held regularly, be public, and be advertised on the public communications channel. 
+PMC meetings should be held regularly, be public, and be advertised on the public communications channel and in the project documentation. 
 Committers have a right to speak, others may be allowed to speak at the discretion of the Chair.
 
 The PMC should make decisions in the usual consensus-seeking manner. 

--- a/open-source-committee/policies/legal.md
+++ b/open-source-committee/policies/legal.md
@@ -1,0 +1,41 @@
+# Legal
+
+## Licenses
+
+Software must be licensed using the Apache 2.0 license.
+Text-based work such as documentation should be licensed under a Creative Commons license.
+
+## Applying the Apache 2.0 license to work
+
+To apply the Apache 2.0 license to your work, two separate files need to be created in the root of the repository:
+
+(1) a “NOTICE” file containing the following boilerplate notice:
+
+```
+Copyright <date range> <copyright owner> 
+
+Licensed under the Apache License, Version 2.0 (the "License”). 
+You may not use this file except in compliance with the License. 
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Unless required by applicable law or agreed to in writing, 
+software distributed under the License is distributed on an 
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+either express or implied. See the License for the specific 
+language governing permissions and limitations under the License.
+```
+
+(2) a “LICENSE” file containing the full license text which can be obtained from [here](http://www.apache.org/licenses/LICENSE-2.0.txt).
+
+<details>
+<summary><b>Rationale</b></summary>
+
+Apache 2.0 is a permissive license that is widely deployed and backed by a strong community. 
+Apache 2.0 allows users the freedom to use the software for any purpose, to distribute it, to modify it, and to distribute modified versions of it under the terms of the license, without any concern about royalties. 
+
+A key advantage of the Apache 2.0 license is that it contains provisions that are absent from many other free and open source licenses (including the MIT license) and which provide more clarity to contributors and users alike. 
+
+However, for text we can typically be much less restrictive.
+For this a permissive license like Creative Commons is much more appropriate.
+
+</details

--- a/open-source-committee/policies/legal.md
+++ b/open-source-committee/policies/legal.md
@@ -1,18 +1,24 @@
 # Legal
 
+## Copyright
+
+Copyright statements should be made where appropriate.
+The copyright holder for Intersect software must be "Intersect MBO".
+The copyright year should be the year of the file's creation and does not need to be updated.
+
 ## Licenses
 
 Software must be licensed using the Apache 2.0 license.
 Text-based work such as documentation should be licensed under a Creative Commons license.
 
-## Applying the Apache 2.0 license to work
+### Applying the Apache 2.0 license to work
 
 To apply the Apache 2.0 license to your work, two separate files need to be created in the root of the repository:
 
 (1) a “NOTICE” file containing the following boilerplate notice:
 
 ```
-Copyright <date range> <copyright owner> 
+Copyright <creation date> Intersect MBO
 
 Licensed under the Apache License, Version 2.0 (the "License”). 
 You may not use this file except in compliance with the License. 
@@ -39,3 +45,4 @@ However, for text we can typically be much less restrictive.
 For this a permissive license like Creative Commons is much more appropriate.
 
 </details
+


### PR DESCRIPTION
- Basic claims about documents that should be present.
- A default CoC
- Basic licensing policy saying that we should be using Apache 2 for now. There is a gap to be filled about copyright assignations, I have left it ambiguous for now and have raised the matter with legal.

A lot of the rest of the content is Cardano-specific, I'm unsure what to do with that. Perhaps we need a Cardano space in the gitbook?